### PR TITLE
Fix Deprecated Required Parameter After Optional Param

### DIFF
--- a/Ui/Component/Form/Fieldset/PasswordSection.php
+++ b/Ui/Component/Form/Fieldset/PasswordSection.php
@@ -37,9 +37,9 @@ class PasswordSection extends Fieldset
      */
     public function __construct(
         ContextInterface $context,
+		Data $helper,
         $components = [],
-        array $data = [],
-        Data $helper
+        array $data = []
     ) {
         parent::__construct($context, $components, $data);
         $this->helper = $helper;


### PR DESCRIPTION
Makes module compatible with newer versions of magento & PHP 8+